### PR TITLE
Fix improper namespacing

### DIFF
--- a/gbpui/column_filters.py
+++ b/gbpui/column_filters.py
@@ -13,7 +13,7 @@
 import os
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.safestring import mark_safe
 
 from gbpui import client

--- a/gbpui/common/forms.py
+++ b/gbpui/common/forms.py
@@ -14,7 +14,7 @@
 
 from horizon import forms
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 
 class ReversingModalFormView(forms.ModalFormView):

--- a/gbpui/fields.py
+++ b/gbpui/fields.py
@@ -12,7 +12,8 @@
 
 from itertools import chain
 
-from django.core import urlresolvers
+from django import urls
+
 from django.forms import fields
 from django.forms import TextInput
 from django.forms import widgets
@@ -43,11 +44,11 @@ class DynamicMultiSelectWidget(widgets.SelectMultiple):
             return self.add_item_link()
         try:
             if self.add_item_link_args:
-                return urlresolvers.reverse(self.add_item_link,
+                return urls.reverse(self.add_item_link,
                                             args=self.add_item_link_args)
             else:
-                return urlresolvers.reverse(self.add_item_link)
-        except urlresolvers.NoReverseMatch:
+                return urls.reverse(self.add_item_link)
+        except urls.NoReverseMatch:
             return self.add_item_link
 
 
@@ -116,7 +117,7 @@ class TransferTableWidget(widgets.SelectMultiple):
         options = self.render_options(choices, selected)
 
         if self.add_item_link is not None:
-            final_attrs['add_item_link'] = urlresolvers.reverse(
+            final_attrs['add_item_link'] = urls.reverse(
                 self.add_item_link
             )
 

--- a/gbpui/panels/application_policy/forms.py
+++ b/gbpui/panels/application_policy/forms.py
@@ -10,9 +10,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from django.core.urlresolvers import reverse
 from django import http
 from django.template.defaultfilters import filesizeformat  # noqa
+from django.urls import reverse
 from django.utils import html
 from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.debug import sensitive_variables  # noqa

--- a/gbpui/panels/application_policy/tables.py
+++ b/gbpui/panels/application_policy/tables.py
@@ -10,7 +10,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ungettext_lazy
 

--- a/gbpui/panels/application_policy/tabs.py
+++ b/gbpui/panels/application_policy/tabs.py
@@ -10,7 +10,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from django.core.urlresolvers import reverse_lazy
+from django.urls import reverse_lazy
 from django.utils.translation import ugettext_lazy as _
 
 from horizon import exceptions
@@ -19,7 +19,7 @@ from horizon import tabs
 from gbpui import client
 from gbpui import column_filters as gfilters
 
-import tables
+from gbpui.panels.application_policy import tables
 
 PolicyRulesTable = tables.PolicyRulesTable
 PolicyClassifiersTable = tables.PolicyClassifiersTable

--- a/gbpui/panels/application_policy/urls.py
+++ b/gbpui/panels/application_policy/urls.py
@@ -13,7 +13,7 @@
 
 from django.conf.urls import url  # noqa
 
-import views
+from gbpui.panels.application_policy import views
 
 urlpatterns = [
     url(r'^$', views.IndexView.as_view(), name='index'),

--- a/gbpui/panels/application_policy/views.py
+++ b/gbpui/panels/application_policy/views.py
@@ -9,14 +9,15 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-from django.core.urlresolvers import reverse
+
+from django.urls import reverse
 
 from horizon import tabs
 from horizon import workflows
 
-import forms as policy_rule_set_forms
-import tabs as policy_rule_set_tabs
-import workflows as policy_rule_set_workflows
+from gbpui.panels.application_policy import forms as policy_rule_set_forms
+from gbpui.panels.application_policy import tabs as policy_rule_set_tabs
+from gbpui.panels.application_policy import workflows as prs_workflows
 
 from django.utils.translation import ugettext_lazy as _
 from gbpui.common import forms as gbforms
@@ -26,9 +27,9 @@ PolicyRuleSetDetailsTabs = policy_rule_set_tabs.PolicyRuleSetDetailsTabs
 PolicyRuleDetailsTabs = policy_rule_set_tabs.PolicyRuleDetailsTabs
 PolicyClassifierDetailsTabs = policy_rule_set_tabs.PolicyClassifierDetailsTabs
 PolicyActionDetailsTabs = policy_rule_set_tabs.PolicyActionDetailsTabs
-AddPolicyRuleSet = policy_rule_set_workflows.AddContract
-AddPolicyRule = policy_rule_set_workflows.AddPolicyRule
-AddPolicyClassifier = policy_rule_set_workflows.AddPolicyClassifier
+AddPolicyRuleSet = prs_workflows.AddContract
+AddPolicyRule = prs_workflows.AddPolicyRule
+AddPolicyClassifier = prs_workflows.AddPolicyClassifier
 
 
 class IndexView(tabs.TabbedTableView):

--- a/gbpui/panels/application_policy/workflows.py
+++ b/gbpui/panels/application_policy/workflows.py
@@ -10,7 +10,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils import html
 from django.utils.translation import ugettext_lazy as _
 

--- a/gbpui/panels/network_policy/forms.py
+++ b/gbpui/panels/network_policy/forms.py
@@ -12,9 +12,9 @@
 
 import logging
 
-from django.core.urlresolvers import reverse
 from django import http
 from django import shortcuts
+from django.urls import reverse
 from django.utils import html
 from django.utils.translation import ugettext_lazy as _
 

--- a/gbpui/panels/network_policy/tables.py
+++ b/gbpui/panels/network_policy/tables.py
@@ -10,7 +10,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ungettext_lazy
 

--- a/gbpui/panels/network_policy/tabs.py
+++ b/gbpui/panels/network_policy/tabs.py
@@ -10,7 +10,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from django.core.urlresolvers import reverse_lazy
+from django.urls import reverse_lazy
 from django.utils.translation import ugettext_lazy as _
 
 from horizon import exceptions
@@ -19,7 +19,7 @@ from horizon import tabs
 from gbpui import client
 from gbpui import column_filters as gfilters
 
-import tables
+from gbpui.panels.network_policy import tables
 
 
 class L3PolicyDetailsTab(tabs.Tab):

--- a/gbpui/panels/network_policy/urls.py
+++ b/gbpui/panels/network_policy/urls.py
@@ -13,7 +13,7 @@
 
 from django.conf.urls import url  # noqa
 
-import views
+from gbpui.panels.network_policy import views
 
 urlpatterns = [
     url(r'^$', views.IndexView.as_view(), name='index'),

--- a/gbpui/panels/network_policy/views.py
+++ b/gbpui/panels/network_policy/views.py
@@ -9,7 +9,8 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-from django.core.urlresolvers import reverse
+
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 
 from horizon import exceptions
@@ -19,9 +20,9 @@ from horizon import tabs
 from gbpui import client
 from gbpui.common import forms as gbforms
 
-import forms as np_forms
-import tables as np_tables
-import tabs as np_tabs
+from gbpui.panels.network_policy import forms as np_forms
+from gbpui.panels.network_policy import tables as np_tables
+from gbpui.panels.network_policy import tabs as np_tabs
 
 
 class IndexView(tabs.TabbedTableView):

--- a/gbpui/panels/network_services/forms.py
+++ b/gbpui/panels/network_services/forms.py
@@ -13,7 +13,7 @@
 import json
 import logging
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils import html
 from django.utils.translation import ugettext_lazy as _
 

--- a/gbpui/panels/network_services/tables.py
+++ b/gbpui/panels/network_services/tables.py
@@ -10,7 +10,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ungettext_lazy
 

--- a/gbpui/panels/network_services/tabs.py
+++ b/gbpui/panels/network_services/tabs.py
@@ -12,12 +12,12 @@
 
 import json
 
-import tables as ns_tables
+from gbpui.panels.network_services import tables as ns_tables
 
 import yaml
 
 from django.contrib.staticfiles.templatetags.staticfiles import static
-from django.core.urlresolvers import reverse_lazy
+from django.urls import reverse_lazy
 from django.utils.translation import ugettext_lazy as _
 
 from horizon import exceptions

--- a/gbpui/panels/network_services/urls.py
+++ b/gbpui/panels/network_services/urls.py
@@ -12,7 +12,7 @@
 
 from django.conf.urls import url  # noqa
 
-import views
+from gbpui.panels.network_services import views
 
 urlpatterns = [
     url(r'^$', views.IndexView.as_view(), name='index'),

--- a/gbpui/panels/network_services/views.py
+++ b/gbpui/panels/network_services/views.py
@@ -12,8 +12,8 @@
 from horizon import forms
 from horizon import tabs
 
-import forms as ns_forms
-import tabs as ns_tabs
+from gbpui.panels.network_services import forms as ns_forms
+from gbpui.panels.network_services import tabs as ns_tabs
 
 from django.utils.translation import ugettext_lazy as _
 from gbpui.common import forms as gbforms

--- a/gbpui/panels/policytargets/forms.py
+++ b/gbpui/panels/policytargets/forms.py
@@ -12,8 +12,8 @@
 
 import logging
 
-from django.core.urlresolvers import reverse
 from django import http
+from django.urls import reverse
 from django.utils import html
 from django.utils.translation import ugettext_lazy as _
 

--- a/gbpui/panels/policytargets/tables.py
+++ b/gbpui/panels/policytargets/tables.py
@@ -11,9 +11,9 @@
 #    under the License.
 import logging
 
-from django.core.urlresolvers import reverse
 from django import http
 from django import shortcuts
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ungettext_lazy
 

--- a/gbpui/panels/policytargets/tabs.py
+++ b/gbpui/panels/policytargets/tabs.py
@@ -12,9 +12,9 @@
 
 import time
 
-import tables
+from gbpui.panels.policytargets import tables
 
-from django.core.urlresolvers import reverse_lazy
+from django.urls import reverse_lazy
 from django.utils.translation import ugettext_lazy as _
 
 from horizon import exceptions

--- a/gbpui/panels/policytargets/urls.py
+++ b/gbpui/panels/policytargets/urls.py
@@ -12,9 +12,9 @@
 
 from django.conf.urls import url  # noqa
 
-import views
+from gbpui.panels.policytargets import views
 
-import restApi
+from gbpui.panels.policytargets import restApi
 
 urlpatterns = [
     url(r'^$',

--- a/gbpui/panels/policytargets/views.py
+++ b/gbpui/panels/policytargets/views.py
@@ -12,8 +12,8 @@
 
 import json
 
-from django.core.urlresolvers import reverse_lazy
 from django.http import HttpResponse  # noqa
+from django.urls import reverse_lazy
 from django.utils.translation import ugettext_lazy as _
 
 from horizon import exceptions
@@ -25,9 +25,9 @@ from gbpui import client
 from gbpui.common import forms as gbforms
 
 
-import forms as policy_target_forms
-import tabs as policy_target_tabs
-import workflows as policy_target_workflows
+import gbpui.panels.policytargets.forms as policy_target_forms
+import gbpui.panels.policytargets.tabs as policy_target_tabs
+import gbpui.panels.policytargets.workflows as policy_target_workflows
 
 from openstack_dashboard import api
 

--- a/gbpui/panels/policytargets/workflows.py
+++ b/gbpui/panels/policytargets/workflows.py
@@ -14,8 +14,8 @@ import logging
 import re
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
 from django import shortcuts
+from django.urls import reverse
 from django.utils import html
 from django.utils.text import normalize_newlines  # noqa
 from django.utils.translation import ugettext_lazy as _


### PR DESCRIPTION
The python module references weren't namespaced. This patch adds
the proper namespacing.